### PR TITLE
GitHub: remove default license

### DIFF
--- a/github-repo/variables.tf
+++ b/github-repo/variables.tf
@@ -127,7 +127,7 @@ variable gitignore_template {
 
 variable license_template {
   type = string
-  default = "mit"
+  default = null
 }
 
 variable archived {


### PR DESCRIPTION
Creates an 'initial commit' with the license otherwise